### PR TITLE
Add translation helper using googletrans

### DIFF
--- a/translate.py
+++ b/translate.py
@@ -1,0 +1,19 @@
+from googletrans import Translator
+
+
+def translate_text(text: str, target_language: str) -> str:
+    """Translate text to a target language using googletrans.
+
+    Args:
+        text: The text to translate.
+        target_language: Language code to translate the text to.
+
+    Returns:
+        The translated text, or the original text if translation fails.
+    """
+    translator = Translator()
+    try:
+        translation = translator.translate(text, dest=target_language)
+        return translation.text
+    except Exception:
+        return text


### PR DESCRIPTION
## Summary
- add `translate_text` function that uses googletrans to translate text and returns original text on failure

## Testing
- `pip install googletrans==4.0.0-rc1` *(fails: Could not find a version, 403)*
- `python -m py_compile translate.py`
- `python - <<'PY'\nfrom translate import translate_text\nprint(translate_text('Hello', 'es'))\nPY` *(fails: ModuleNotFoundError: googletrans)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d325c8a4832494400d15f39e6d96